### PR TITLE
expose more qweb* classes to scripting

### DIFF
--- a/guiclient/guiclient.pro
+++ b/guiclient/guiclient.pro
@@ -1,9 +1,17 @@
 include( ../global.pri )
 
 TARGET   = xtuple
-CONFIG   += qt warn_on uitools designer help
 TEMPLATE = app
-QT += designer help uitools
+
+CONFIG += qt warn_on
+QT     += xml sql script scripttools network \
+          webkit xmlpatterns printsupport webkitwidgets
+lessThan(QT_MAJOR_VERSION, 5) {
+  CONFIG += uitools designer help
+} else {
+  QT     += designer help quick uitools websockets
+}
+
 
 INCLUDEPATH += ../scriptapi \
                ../common \
@@ -1858,10 +1866,5 @@ SOURCES = absoluteCalendarItem.cpp              \
 include( displays/displays.pri )
 include( hunspell.pri )
 
-QT += xml sql script scripttools network quick
-QT += webkit xmlpatterns printsupport webkitwidgets
-
 RESOURCES += guiclient.qrc $${OPENRPT_IMAGE_DIR}/OpenRPTMetaSQL.qrc
-
-#CONFIG += debug
 

--- a/scriptapi/qjsondocumentproto.cpp
+++ b/scriptapi/qjsondocumentproto.cpp
@@ -151,7 +151,7 @@ QJsonDocument & QJsonDocumentProto::operator=(const QJsonDocument & other)
   QJsonDocument *item = qscriptvalue_cast<QJsonDocument*>(thisObject());
   if (item)
     return item->operator=(other);
-  return QJsonDocument();
+  return *(new QJsonDocument());
 }
 
 bool QJsonDocumentProto::operator==(const QJsonDocument & other) const

--- a/scriptapi/qjsondocumentproto.cpp
+++ b/scriptapi/qjsondocumentproto.cpp
@@ -10,6 +10,12 @@
 
 #include "qjsondocumentproto.h"
 
+#if QT_VERSION < 0x050000
+void setupQJsonDocumentProto(QScriptEngine *engine)
+{
+  // do nothing
+}
+#else
 #include <QJsonDocument>
 
 void setupQJsonDocumentProto(QScriptEngine *engine)
@@ -26,11 +32,6 @@ QScriptValue constructQJsonDocument(QScriptContext * context,
                                     QScriptEngine  *engine)
 {
   QJsonDocument *obj = 0;
-  /* TODO QVariant::QJsonDocument doesn't exist
-   * https://github.com/qtproject/qtbase/blob/dev/src/corelib/kernel/qvariant.h#L125-L191
-  if (context->argumentCount() == 1 && context->argument(0).isVariant() &&
-        context->argument(0).toVariant().type() == QVariant::QJsonDocument)
-  */
   if (context->argumentCount() == 1 && context->argument(0).isVariant())
     obj = new QJsonDocument(context->argument(0).toVariant().toJsonDocument());
   else
@@ -103,14 +104,14 @@ void QJsonDocumentProto::setArray(const QJsonArray & array)
 {
   QJsonDocument *item = qscriptvalue_cast<QJsonDocument*>(thisObject());
   if (item)
-    return item->setArray(array);
+    item->setArray(array);
 }
 
 void QJsonDocumentProto::setObject(const QJsonObject & object)
 {
   QJsonDocument *item = qscriptvalue_cast<QJsonDocument*>(thisObject());
   if (item)
-    return item->setObject(object);
+    item->setObject(object);
 }
 
 QByteArray QJsonDocumentProto::toBinaryData() const
@@ -150,8 +151,7 @@ QJsonDocument & QJsonDocumentProto::operator=(const QJsonDocument & other)
   QJsonDocument *item = qscriptvalue_cast<QJsonDocument*>(thisObject());
   if (item)
     return item->operator=(other);
-  // TODO: What should be returned here?
-  //return QJsonDocument();
+  return QJsonDocument();
 }
 
 bool QJsonDocumentProto::operator==(const QJsonDocument & other) const
@@ -193,3 +193,4 @@ QJsonDocument QJsonDocumentProto::fromVariant(const QVariant & variant)
     return item->fromVariant(variant);
   return QJsonDocument();
 }
+#endif

--- a/scriptapi/qjsondocumentproto.h
+++ b/scriptapi/qjsondocumentproto.h
@@ -11,12 +11,16 @@
 #ifndef __QJSONDOCUMENTPROTO_H__
 #define __QJSONDOCUMENTPROTO_H__
 
+#include <QtScript>
+
+void setupQJsonDocumentProto(QScriptEngine *engine);
+
+#if QT_VERSION >= 0x050000
 #include <QByteArray>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonParseError>
-#include <QtScript>
 #include <QVariant>
 
 Q_DECLARE_METATYPE(QJsonDocument*)
@@ -24,7 +28,6 @@ Q_DECLARE_METATYPE(QJsonDocument*)
 Q_DECLARE_METATYPE(enum QJsonDocument::JsonFormat)
 Q_DECLARE_METATYPE(enum QJsonDocument::DataValidation)
 
-void setupQJsonDocumentProto(QScriptEngine *engine);
 QScriptValue constructQJsonDocument(QScriptContext *context, QScriptEngine *engine);
 
 class QJsonDocumentProto : public QObject, public QScriptable
@@ -56,4 +59,5 @@ class QJsonDocumentProto : public QObject, public QScriptable
     Q_INVOKABLE QJsonDocument  fromVariant(const QVariant & variant);
 };
 
+#endif
 #endif

--- a/scriptapi/qjsonobjectproto.cpp
+++ b/scriptapi/qjsonobjectproto.cpp
@@ -10,6 +10,14 @@
 
 #include "qjsonobjectproto.h"
 
+#if QT_VERSION < 0x050000
+void setupQJsonObjectProto(QScriptEngine *engine)
+{
+  // do nothing
+}
+
+#else
+
 #include <QJsonObject>
 
 QScriptValue QJsonObjecttoScriptValue(QScriptEngine *engine, QJsonObject::iterator const &iterator)
@@ -40,11 +48,6 @@ QScriptValue constructQJsonObject(QScriptContext * context,
                                     QScriptEngine  *engine)
 {
   QJsonObject *obj = 0;
-  /* TODO QVariant::QJsonObject doesn't exist
-   * https://github.com/qtproject/qtbase/blob/dev/src/corelib/kernel/qvariant.h#L125-L191
-  if (context->argumentCount() == 1 && context->argument(0).isVariant() &&
-        context->argument(0).toVariant().type() == QVariant::QJsonObject)
-  */
   if (context->argumentCount() == 1 && context->argument(0).isVariant())
     obj = new QJsonObject(context->argument(0).toVariant().toJsonObject());
   else
@@ -62,7 +65,7 @@ QJsonObject::iterator QJsonObjectProto::begin()
   QJsonObject *item = qscriptvalue_cast<QJsonObject*>(thisObject());
   if (item)
     return item->begin();
-  // TODO: What to return here:
+  return QJsonObject::iterator();
 }
 
 QJsonObject::const_iterator QJsonObjectProto::begin() const
@@ -70,7 +73,7 @@ QJsonObject::const_iterator QJsonObjectProto::begin() const
   QJsonObject *item = qscriptvalue_cast<QJsonObject*>(thisObject());
   if (item)
     return item->begin();
-  // TODO: What to return here:
+  return QJsonObject::const_iterator();
 }
 
 QJsonObject::const_iterator QJsonObjectProto::constBegin() const
@@ -78,7 +81,7 @@ QJsonObject::const_iterator QJsonObjectProto::constBegin() const
   QJsonObject *item = qscriptvalue_cast<QJsonObject*>(thisObject());
   if (item)
     return item->constBegin();
-  // TODO: What to return here:
+  return QJsonObject::const_iterator();
 }
 
 QJsonObject::const_iterator QJsonObjectProto::constEnd() const
@@ -86,7 +89,7 @@ QJsonObject::const_iterator QJsonObjectProto::constEnd() const
   QJsonObject *item = qscriptvalue_cast<QJsonObject*>(thisObject());
   if (item)
     return item->constEnd();
-  // TODO: What to return here:
+  return QJsonObject::const_iterator();
 }
 
 QJsonObject::const_iterator QJsonObjectProto::constFind(const QString & key) const
@@ -94,7 +97,7 @@ QJsonObject::const_iterator QJsonObjectProto::constFind(const QString & key) con
   QJsonObject *item = qscriptvalue_cast<QJsonObject*>(thisObject());
   if (item)
     return item->constFind(key);
-  // TODO: What to return here:
+  return QJsonObject::const_iterator();
 }
 
 bool QJsonObjectProto::contains(const QString & key) const
@@ -126,7 +129,7 @@ QJsonObject::iterator QJsonObjectProto::end()
   QJsonObject *item = qscriptvalue_cast<QJsonObject*>(thisObject());
   if (item)
     return item->end();
-  // TODO: What to return here:
+  return QJsonObject::iterator();
 }
 
 QJsonObject::const_iterator QJsonObjectProto::end() const
@@ -134,7 +137,7 @@ QJsonObject::const_iterator QJsonObjectProto::end() const
   QJsonObject *item = qscriptvalue_cast<QJsonObject*>(thisObject());
   if (item)
     return item->end();
-  // TODO: What to return here:
+  return QJsonObject::const_iterator();
 }
 
 QJsonObject::iterator QJsonObjectProto::erase(QJsonObject::iterator it)
@@ -142,7 +145,7 @@ QJsonObject::iterator QJsonObjectProto::erase(QJsonObject::iterator it)
   QJsonObject *item = qscriptvalue_cast<QJsonObject*>(thisObject());
   if (item)
     return item->erase(it);
-  // TODO: What to return here:
+  return QJsonObject::iterator();
 }
 
 QJsonObject::iterator QJsonObjectProto::find(const QString & key)
@@ -150,7 +153,7 @@ QJsonObject::iterator QJsonObjectProto::find(const QString & key)
   QJsonObject *item = qscriptvalue_cast<QJsonObject*>(thisObject());
   if (item)
     return item->find(key);
-  // TODO: What to return here:
+  return QJsonObject::iterator();
 }
 
 QJsonObject::const_iterator QJsonObjectProto::find(const QString & key) const
@@ -158,7 +161,7 @@ QJsonObject::const_iterator QJsonObjectProto::find(const QString & key) const
   QJsonObject *item = qscriptvalue_cast<QJsonObject*>(thisObject());
   if (item)
     return item->find(key);
-  // TODO: What to return here:
+  return QJsonObject::const_iterator();
 }
 
 QJsonObject::iterator QJsonObjectProto::insert(const QString & key, const QJsonValue & value)
@@ -166,7 +169,7 @@ QJsonObject::iterator QJsonObjectProto::insert(const QString & key, const QJsonV
   QJsonObject *item = qscriptvalue_cast<QJsonObject*>(thisObject());
   if (item)
     return item->insert(key, value);
-  // TODO: What to return here:
+  return QJsonObject::iterator();
 }
 
 bool QJsonObjectProto::isEmpty() const
@@ -197,7 +200,7 @@ void QJsonObjectProto::remove(const QString & key)
 {
   QJsonObject *item = qscriptvalue_cast<QJsonObject*>(thisObject());
   if (item)
-    return item->remove(key);
+    item->remove(key);
 }
 
 int QJsonObjectProto::size() const
@@ -216,8 +219,6 @@ QJsonValue QJsonObjectProto::take(const QString & key)
   return QJsonValue();
 }
 
-/*
- * TODO: error: 'class QJsonObject' has no member named 'toVariantHash'
 QVariantHash QJsonObjectProto::toVariantHash() const
 {
   QJsonObject *item = qscriptvalue_cast<QJsonObject*>(thisObject());
@@ -225,7 +226,6 @@ QVariantHash QJsonObjectProto::toVariantHash() const
     return item->toVariantHash();
   return QVariantHash();
 }
-*/
 
 QVariantMap QJsonObjectProto::toVariantMap() const
 {
@@ -256,8 +256,7 @@ QJsonObject & QJsonObjectProto::operator=(const QJsonObject & other)
   QJsonObject *item = qscriptvalue_cast<QJsonObject*>(thisObject());
   if (item)
     return item->operator=(other);
-  // TODO: What should be returned here?
-  //return QJsonObject();
+  return QJsonObject();
 }
 
 bool QJsonObjectProto::operator==(const QJsonObject & other) const
@@ -281,26 +280,16 @@ QJsonValueRef QJsonObjectProto::operator[](const QString & key)
   QJsonObject *item = qscriptvalue_cast<QJsonObject*>(thisObject());
   if (item)
     return item->operator[](key);
-  // TODO: What should be returned here?
-  //return QJsonValueRef();
+  return QJsonValueRef();
 }
 
-/*
- * TODO: error: 'class QJsonObject' has no member named 'fromVariantHash'
 QJsonObject QJsonObjectProto::fromVariantHash(const QVariantHash & hash)
 {
-  QJsonObject *item = qscriptvalue_cast<QJsonObject*>(thisObject());
-  if (item)
-    return item->fromVariantHash(hash);
-  // TODO: What should be returned here?
-  //return QJsonObject();
+  return QJsonObject::fromVariantHash(hash);
 }
-*/
 
 QJsonObject QJsonObjectProto::fromVariantMap(const QVariantMap & map)
 {
-  QJsonObject *item = qscriptvalue_cast<QJsonObject*>(thisObject());
-  if (item)
-    return item->fromVariantMap(map);
-  return QJsonObject();
+  return QJsonObject::fromVariantMap(map);
 }
+#endif

--- a/scriptapi/qjsonobjectproto.h
+++ b/scriptapi/qjsonobjectproto.h
@@ -23,12 +23,19 @@ void setupQJsonObjectProto(QScriptEngine *engine);
 #include <QVariantHash>
 #include <QVariantMap>
 
+// uncomment the following when/if we need to iterate; better to just use JS
+// #define Use_QJsonObjectIterators
+
 Q_DECLARE_METATYPE(QJsonObject*)
 
+#ifdef Use_QJsonObjectIterators
 Q_DECLARE_METATYPE(QJsonObject::iterator)
 Q_DECLARE_METATYPE(QJsonObject::const_iterator)
+#endif
 
 QScriptValue constructQJsonObject(QScriptContext *context, QScriptEngine *engine);
+QScriptValue QJsonObjectToScriptValue(QScriptEngine *engine, QJsonObject* const &in);
+void QJsonObjectFromScriptValue(const QScriptValue &obj, QJsonObject* &out);
 
 class QJsonObjectProto : public QObject, public QScriptable
 {
@@ -37,27 +44,31 @@ class QJsonObjectProto : public QObject, public QScriptable
   public:
     QJsonObjectProto(QObject *parent = 0);
 
+#ifdef Use_QJsonObjectIterators
     Q_INVOKABLE QJsonObject::iterator         begin();
     Q_INVOKABLE QJsonObject::const_iterator   begin() const;
     Q_INVOKABLE QJsonObject::const_iterator   constBegin() const;
     Q_INVOKABLE QJsonObject::const_iterator   constEnd() const;
     Q_INVOKABLE QJsonObject::const_iterator   constFind(const QString & key) const;
+#endif
     Q_INVOKABLE bool                          contains(const QString & key) const;
     Q_INVOKABLE int                           count() const;
     Q_INVOKABLE bool                          empty() const;
+#ifdef Use_QJsonObjectIterators
     Q_INVOKABLE QJsonObject::iterator         end();
     Q_INVOKABLE QJsonObject::const_iterator   end() const;
     Q_INVOKABLE QJsonObject::iterator         erase(QJsonObject::iterator it);
     Q_INVOKABLE QJsonObject::iterator         find(const QString & key);
     Q_INVOKABLE QJsonObject::const_iterator   find(const QString & key) const;
     Q_INVOKABLE QJsonObject::iterator         insert(const QString & key, const QJsonValue & value);
+#endif
     Q_INVOKABLE bool                          isEmpty() const;
     Q_INVOKABLE QStringList                   keys() const;
     Q_INVOKABLE int                           length() const;
     Q_INVOKABLE void                          remove(const QString & key);
     Q_INVOKABLE int                           size() const;
     Q_INVOKABLE QJsonValue                    take(const QString & key);
-    //Q_INVOKABLE QVariantHash                  toVariantHash() const;
+    Q_INVOKABLE QVariantHash                  toVariantHash() const;
     Q_INVOKABLE QVariantMap                   toVariantMap() const;
     Q_INVOKABLE QJsonValue                    value(const QString & key) const;
     Q_INVOKABLE bool                          operator!=(const QJsonObject & other) const;
@@ -65,10 +76,6 @@ class QJsonObjectProto : public QObject, public QScriptable
     Q_INVOKABLE bool                          operator==(const QJsonObject & other) const;
     Q_INVOKABLE QJsonValue                    operator[](const QString & key) const;
     Q_INVOKABLE QJsonValueRef                 operator[](const QString & key);
-
-    // TODO: error: 'class QJsonObject' has no member named 'fromVariantHash'
-    //Q_INVOKABLE QJsonObject                   fromVariantHash(const QVariantHash & hash);
-    Q_INVOKABLE QJsonObject                   fromVariantMap(const QVariantMap & map);
 };
 
 #endif

--- a/scriptapi/qjsonobjectproto.h
+++ b/scriptapi/qjsonobjectproto.h
@@ -11,12 +11,15 @@
 #ifndef __QJSONOBJECTPROTO_H__
 #define __QJSONOBJECTPROTO_H__
 
+#include <QtScript>
+void setupQJsonObjectProto(QScriptEngine *engine);
+
+#if QT_VERSION >= 0x050000
 #include <QJsonValue>
 #include <QJsonValueRef>
 #include <QJsonObject>
 #include <QString>
 #include <QStringList>
-#include <QtScript>
 #include <QVariantHash>
 #include <QVariantMap>
 
@@ -25,7 +28,6 @@ Q_DECLARE_METATYPE(QJsonObject*)
 Q_DECLARE_METATYPE(QJsonObject::iterator)
 Q_DECLARE_METATYPE(QJsonObject::const_iterator)
 
-void setupQJsonObjectProto(QScriptEngine *engine);
 QScriptValue constructQJsonObject(QScriptContext *context, QScriptEngine *engine);
 
 class QJsonObjectProto : public QObject, public QScriptable
@@ -69,4 +71,5 @@ class QJsonObjectProto : public QObject, public QScriptable
     Q_INVOKABLE QJsonObject                   fromVariantMap(const QVariantMap & map);
 };
 
+#endif
 #endif

--- a/scriptapi/qjsonvalueproto.cpp
+++ b/scriptapi/qjsonvalueproto.cpp
@@ -10,15 +10,20 @@
 
 #include "qjsonvalueproto.h"
 
+#if QT_VERSION < 0x050000
+void setupQJsonValueProto(QScriptEngine *engine)
+{
+  Q_UNUSED(engine); // do nothing
+}
+
+#else
 QScriptValue QJsonValuetoScriptValue(QScriptEngine *engine, QJsonValue::Type const &type)
 {
-  //return engine->newQObject(item);
   return engine->newVariant(QVariant(&type));
 }
 
 void QJsonValuefromScriptValue(const QScriptValue &obj, QJsonValue::Type &type)
 {
-  //item = qobject_cast<QJsonValue*>(obj.toQObject());
   type = qscriptvalue_cast<QJsonValue::Type>(obj);
 }
 
@@ -35,17 +40,14 @@ void setupQJsonValueProto(QScriptEngine *engine)
   engine->globalObject().setProperty("QJsonValue",  constructor);
 }
 
-QScriptValue constructQJsonValue(QScriptContext * /*context*/,
+QScriptValue constructQJsonValue(QScriptContext *context,
                                     QScriptEngine  *engine)
 {
-  QJsonValue *obj = 0;
-  /* if (context->argumentCount() ...)
-  else if (something bad)
-    context->throwError(QScriptContext::UnknownError,
-                        "Could not find an appropriate QJsonValueconstructor");
-  else
-  */
-    obj = new QJsonValue();
+  Q_UNUSED(context);
+  QJsonValue *obj = new QJsonValue();
+
+  if (context->argumentCount() >= 1)
+    *obj = QJsonValue::fromVariant(context->argument(0));
   return engine->toScriptValue(obj);
 }
 
@@ -203,8 +205,7 @@ QJsonValue & QJsonValueProto::operator=(const QJsonValue & other)
   QJsonValue *item = qscriptvalue_cast<QJsonValue*>(thisObject());
   if (item)
     return item->operator=(other);
-  // TODO: What should be returned here?
-  //return QJsonValue();
+  return QJsonValue();
 }
 
 bool QJsonValueProto::operator==(const QJsonValue & other) const
@@ -217,10 +218,7 @@ bool QJsonValueProto::operator==(const QJsonValue & other) const
 
 QJsonValue QJsonValueProto::fromVariant(const QVariant & variant)
 {
-  QJsonValue *item = qscriptvalue_cast<QJsonValue*>(thisObject());
-  if (item)
-    return item->fromVariant(variant);
-  // TODO: What should be returned here?
-  //return QJsonValue();
+  return QJsonValue::fromVariant(variant);
 }
 
+#endif

--- a/scriptapi/qjsonvalueproto.h
+++ b/scriptapi/qjsonvalueproto.h
@@ -21,8 +21,8 @@ void setupQJsonValueProto(QScriptEngine *engine);
 #include <QString>
 #include <QVariant>
 
+Q_DECLARE_METATYPE(QJsonValue)
 Q_DECLARE_METATYPE(QJsonValue*)
-
 Q_DECLARE_METATYPE(enum QJsonValue::Type)
 
 QScriptValue constructQJsonValue(QScriptContext *context, QScriptEngine *engine);

--- a/scriptapi/qjsonvalueproto.h
+++ b/scriptapi/qjsonvalueproto.h
@@ -11,18 +11,20 @@
 #ifndef __QJSONVALUEPROTO_H__
 #define __QJSONVALUEPROTO_H__
 
+#include <QtScript>
+void setupQJsonValueProto(QScriptEngine *engine);
+
+#if QT_VERSION >= 0x050000
 #include <QJsonArray>
 #include <QJsonObject>
 #include <QJsonValue>
 #include <QString>
-#include <QtScript>
 #include <QVariant>
 
 Q_DECLARE_METATYPE(QJsonValue*)
 
 Q_DECLARE_METATYPE(enum QJsonValue::Type)
 
-void setupQJsonValueProto(QScriptEngine *engine);
 QScriptValue constructQJsonValue(QScriptContext *context, QScriptEngine *engine);
 
 class QJsonValueProto : public QObject, public QScriptable
@@ -56,4 +58,5 @@ class QJsonValueProto : public QObject, public QScriptable
     Q_INVOKABLE QJsonValue        fromVariant(const QVariant & variant);
 };
 
+#endif
 #endif

--- a/scriptapi/qnetworkaccessmanagerproto.cpp
+++ b/scriptapi/qnetworkaccessmanagerproto.cpp
@@ -12,6 +12,7 @@
 
 #include <QNetworkAccessManager>
 
+// TODO: either complete this or remove it. we don't need this if all we're looking for is signals
 void setupQNetworkAccessManagerCoreProto(QScriptEngine *engine)
 {
   QScriptValue replyproto = engine->newQObject(new QNetworkAccessManagerProto(engine));
@@ -21,11 +22,4 @@ void setupQNetworkAccessManagerCoreProto(QScriptEngine *engine)
 QNetworkAccessManagerProto::QNetworkAccessManagerProto(QObject *parent)
   : QObject(parent)
 {
-}
-
-void QNetworkAccessManagerProto::sslErrors(QNetworkReply * reply, const QList<QSslError> & errors)
-{
-  QNetworkAccessManager *item = qscriptvalue_cast<QNetworkAccessManager*>(thisObject());
-  if (item)
-    item->sslErrors(reply, errors);
 }

--- a/scriptapi/qnetworkaccessmanagerproto.h
+++ b/scriptapi/qnetworkaccessmanagerproto.h
@@ -9,7 +9,7 @@
  */
 
 #ifndef __QNETWORKACCESSMANAGERPROTO_H__
-#define __QNETWORKACCESSMANAGER_H__
+#define __QNETWORKACCESSMANAGERPROTO_H__
 
 #include <QList>
 #include <QNetworkAccessManager>
@@ -30,7 +30,6 @@ class QNetworkAccessManagerProto : public QObject, public QScriptable
   public:
     QNetworkAccessManagerProto(QObject *parent);
 
-    Q_INVOKABLE void      sslErrors(QNetworkReply * reply, const QList<QSslError> & errors);
 };
 
 #endif

--- a/scriptapi/qwebframeproto.cpp
+++ b/scriptapi/qwebframeproto.cpp
@@ -52,6 +52,7 @@ void setupQWebFrameProto(QScriptEngine *engine)
 QScriptValue constructQWebFrame(QScriptContext * context,
                                     QScriptEngine  *engine)
 {
+  Q_UNUSED(context);
   QWebFrame *obj = 0;
 
   return engine->toScriptValue(obj);
@@ -62,12 +63,14 @@ QWebFrameProto::QWebFrameProto(QObject *parent)
 {
 }
 
+#if QT_VERSION >= 0x050000
 void QWebFrameProto::addToJavaScriptWindowObject(const QString & name, QObject * object, QWebFrame::ValueOwnership own)
 {
   QWebFrame *item = qscriptvalue_cast<QWebFrame*>(thisObject());
   if (item)
-    return item->addToJavaScriptWindowObject(name, object, own);
+    item->addToJavaScriptWindowObject(name, object, own);
 }
+#endif
 
 QUrl QWebFrameProto::baseUrl() const
 {
@@ -141,7 +144,6 @@ bool QWebFrameProto::hasFocus() const
   return false;
 }
 
-/* TODO - else no `item` return what? */
 QWebHitTestResult QWebFrameProto::hitTestContent(const QPoint & pos) const
 {
   QWebFrame *item = qscriptvalue_cast<QWebFrame*>(thisObject());
@@ -162,14 +164,14 @@ void QWebFrameProto::load(const QUrl & url)
 {
   QWebFrame *item = qscriptvalue_cast<QWebFrame*>(thisObject());
   if (item)
-    return item->load(url);
+    item->load(url);
 }
 
 void QWebFrameProto::load(const QNetworkRequest & req, QNetworkAccessManager::Operation operation, const QByteArray & body)
 {
   QWebFrame *item = qscriptvalue_cast<QWebFrame*>(thisObject());
   if (item)
-    return item->load(req, operation, body);
+    item->load(req, operation, body);
 }
 
 QMultiMap<QString, QString> QWebFrameProto::metaData() const
@@ -208,14 +210,14 @@ void QWebFrameProto::render(QPainter * painter, const QRegion & clip)
 {
   QWebFrame *item = qscriptvalue_cast<QWebFrame*>(thisObject());
   if (item)
-    return item->render(painter, clip);
+    item->render(painter, clip);
 }
 
-void QWebFrameProto::render(QPainter * painter, QWebFrame::RenderLayers layer, const QRegion & clip)
+void QWebFrameProto::render(QPainter * painter, int layer, const QRegion & clip)
 {
   QWebFrame *item = qscriptvalue_cast<QWebFrame*>(thisObject());
   if (item)
-    return item->render(painter, layer, clip);
+    item->render(painter, QWebFrame::RenderLayer(layer), clip);
 }
 
 QUrl QWebFrameProto::requestedUrl() const
@@ -262,7 +264,7 @@ Qt::ScrollBarPolicy QWebFrameProto::scrollBarPolicy(Qt::Orientation orientation)
   QWebFrame *item = qscriptvalue_cast<QWebFrame*>(thisObject());
   if (item)
     return item->scrollBarPolicy(orientation);
-  return Qt::ScrollBarPolicy();
+  return Qt::ScrollBarAsNeeded;
 }
 
 int QWebFrameProto::scrollBarValue(Qt::Orientation orientation) const
@@ -285,78 +287,82 @@ void QWebFrameProto::scrollToAnchor(const QString & anchor)
 {
   QWebFrame *item = qscriptvalue_cast<QWebFrame*>(thisObject());
   if (item)
-    return item->scrollToAnchor(anchor);
+    item->scrollToAnchor(anchor);
 }
 
-/* TODO - else no `item` return what? */
 QWebSecurityOrigin QWebFrameProto::securityOrigin() const
 {
   QWebFrame *item = qscriptvalue_cast<QWebFrame*>(thisObject());
   if (item)
     return item->securityOrigin();
+#if QT_VERSION >= 0x050000
+  return QWebSecurityOrigin(QUrl());
+#else
+  return QWebSecurityOrigin(QWebSecurityOrigin::allOrigins().first()); // TODO: what's better?
+#endif
 }
 
 void QWebFrameProto::setContent(const QByteArray & data, const QString & mimeType, const QUrl & baseUrl)
 {
   QWebFrame *item = qscriptvalue_cast<QWebFrame*>(thisObject());
   if (item)
-    return item->setContent(data, mimeType, baseUrl);
+    item->setContent(data, mimeType, baseUrl);
 }
 
 void QWebFrameProto::setFocus()
 {
   QWebFrame *item = qscriptvalue_cast<QWebFrame*>(thisObject());
   if (item)
-    return item->setFocus();
+    item->setFocus();
 }
 
 void QWebFrameProto::setHtml(const QString & html, const QUrl & baseUrl)
 {
   QWebFrame *item = qscriptvalue_cast<QWebFrame*>(thisObject());
   if (item)
-    return item->setHtml(html, baseUrl);
+    item->setHtml(html, baseUrl);
 }
 
 void QWebFrameProto::setScrollBarPolicy(Qt::Orientation orientation, Qt::ScrollBarPolicy policy)
 {
   QWebFrame *item = qscriptvalue_cast<QWebFrame*>(thisObject());
   if (item)
-    return item->setScrollBarPolicy(orientation, policy);
+    item->setScrollBarPolicy(orientation, policy);
 }
 
 void QWebFrameProto::setScrollBarValue(Qt::Orientation orientation, int value)
 {
   QWebFrame *item = qscriptvalue_cast<QWebFrame*>(thisObject());
   if (item)
-    return item->setScrollBarValue(orientation, value);
+    item->setScrollBarValue(orientation, value);
 }
 
 void QWebFrameProto::setScrollPosition(const QPoint & pos)
 {
   QWebFrame *item = qscriptvalue_cast<QWebFrame*>(thisObject());
   if (item)
-    return item->setScrollPosition(pos);
+    item->setScrollPosition(pos);
 }
 
 void QWebFrameProto::setTextSizeMultiplier(qreal factor)
 {
   QWebFrame *item = qscriptvalue_cast<QWebFrame*>(thisObject());
   if (item)
-    return item->setTextSizeMultiplier(factor);
+    item->setTextSizeMultiplier(factor);
 }
 
 void QWebFrameProto::setUrl(const QUrl & url)
 {
   QWebFrame *item = qscriptvalue_cast<QWebFrame*>(thisObject());
   if (item)
-    return item->setUrl(url);
+    item->setUrl(url);
 }
 
 void QWebFrameProto::setZoomFactor(qreal factor)
 {
   QWebFrame *item = qscriptvalue_cast<QWebFrame*>(thisObject());
   if (item)
-    return item->setZoomFactor(factor);
+    item->setZoomFactor(factor);
 }
 
 qreal QWebFrameProto::textSizeMultiplier() const
@@ -419,5 +425,5 @@ void QWebFrameProto::print(QPrinter * printer) const
 {
   QWebFrame *item = qscriptvalue_cast<QWebFrame*>(thisObject());
   if (item)
-    return item->print(printer);
+    item->print(printer);
 }

--- a/scriptapi/qwebframeproto.h
+++ b/scriptapi/qwebframeproto.h
@@ -34,7 +34,11 @@
 #include <QWebSecurityOrigin>
 
 Q_DECLARE_METATYPE(QWebFrame*)
+
+#if QT_VERSION >= 0x050000
 Q_DECLARE_METATYPE(enum QWebFrame::ValueOwnership)
+#endif
+Q_DECLARE_METATYPE(enum QWebFrame::RenderLayer)
 
 void setupQWebFrameProto(QScriptEngine *engine);
 QScriptValue constructQWebFrame(QScriptContext *context, QScriptEngine *engine);
@@ -46,7 +50,9 @@ class QWebFrameProto : public QObject, public QScriptable
   public:
     QWebFrameProto(QObject *parent);
 
+#if QT_VERSION >= 0x050000
     Q_INVOKABLE void                          addToJavaScriptWindowObject(const QString & name, QObject * object, QWebFrame::ValueOwnership own = QWebFrame::QtOwnership);
+#endif
     Q_INVOKABLE QUrl                          baseUrl() const;
     Q_INVOKABLE QList<QWebFrame *>            childFrames() const;
     Q_INVOKABLE QSize                         contentsSize() const;
@@ -65,7 +71,7 @@ class QWebFrameProto : public QObject, public QScriptable
     Q_INVOKABLE QWebFrame                    *parentFrame() const;
     Q_INVOKABLE QPoint                        pos() const;
     Q_INVOKABLE void                          render(QPainter * painter, const QRegion & clip = QRegion());
-    Q_INVOKABLE void                          render(QPainter * painter, QWebFrame::RenderLayers layer, const QRegion & clip = QRegion());
+    Q_INVOKABLE void                          render(QPainter * painter, int layer, const QRegion & clip = QRegion());
     Q_INVOKABLE QUrl                          requestedUrl() const;
     Q_INVOKABLE void                          scroll(int dx, int dy);
     Q_INVOKABLE QRect                         scrollBarGeometry(Qt::Orientation orientation) const;

--- a/scriptapi/qwebpageproto.cpp
+++ b/scriptapi/qwebpageproto.cpp
@@ -248,86 +248,87 @@ void QWebPageProto::setActualVisibleContentRect(const QRect & rect) const
 {
   QWebPage *item = qscriptvalue_cast<QWebPage*>(thisObject());
   if (item)
-    return item->setActualVisibleContentRect(rect);
+    item->setActualVisibleContentRect(rect);
 }
 
 void QWebPageProto::setContentEditable(bool editable)
 {
   QWebPage *item = qscriptvalue_cast<QWebPage*>(thisObject());
   if (item)
-    return item->setContentEditable(editable);
+    item->setContentEditable(editable);
 }
 
 void QWebPageProto::setFeaturePermission(QWebFrame * frame, QWebPage::Feature feature, QWebPage::PermissionPolicy policy)
 {
   QWebPage *item = qscriptvalue_cast<QWebPage*>(thisObject());
   if (item)
-    return item->setFeaturePermission(frame, feature, policy);
+    item->setFeaturePermission(frame, feature, policy);
 }
 
 void QWebPageProto::setForwardUnsupportedContent(bool forward)
 {
   QWebPage *item = qscriptvalue_cast<QWebPage*>(thisObject());
   if (item)
-    return item->setForwardUnsupportedContent(forward);
+    item->setForwardUnsupportedContent(forward);
 }
 
 void QWebPageProto::setLinkDelegationPolicy(QWebPage::LinkDelegationPolicy policy)
 {
   QWebPage *item = qscriptvalue_cast<QWebPage*>(thisObject());
   if (item)
-    return item->setLinkDelegationPolicy(policy);
+    item->setLinkDelegationPolicy(policy);
 }
 
 void QWebPageProto::setNetworkAccessManager(QNetworkAccessManager * manager)
 {
   QWebPage *item = qscriptvalue_cast<QWebPage*>(thisObject());
   if (item)
-    return item->setNetworkAccessManager(manager);
+    item->setNetworkAccessManager(manager);
 }
 
 void QWebPageProto::setPalette(const QPalette & palette)
 {
   QWebPage *item = qscriptvalue_cast<QWebPage*>(thisObject());
   if (item)
-    return item->setPalette(palette);
+    item->setPalette(palette);
 }
 
 void QWebPageProto::setPluginFactory(QWebPluginFactory * factory)
 {
   QWebPage *item = qscriptvalue_cast<QWebPage*>(thisObject());
   if (item)
-    return item->setPluginFactory(factory);
+    item->setPluginFactory(factory);
 }
 
 void QWebPageProto::setPreferredContentsSize(const QSize & size) const
 {
   QWebPage *item = qscriptvalue_cast<QWebPage*>(thisObject());
   if (item)
-    return item->setPreferredContentsSize(size);
+    item->setPreferredContentsSize(size);
 }
 
 void QWebPageProto::setView(QWidget * view)
 {
   QWebPage *item = qscriptvalue_cast<QWebPage*>(thisObject());
   if (item)
-    return item->setView(view);
+    item->setView(view);
 }
 
 void QWebPageProto::setViewportSize(const QSize & size) const
 {
   QWebPage *item = qscriptvalue_cast<QWebPage*>(thisObject());
   if (item)
-    return item->setViewportSize(size);
+    item->setViewportSize(size);
 }
 
-/* TODO - Qt docs only have (VisibilityState), not assigned to a var. */
-void QWebPageProto::setVisibilityState(QWebPage::VisibilityState)
+#if QT_VERSION >= 0x050000
+void QWebPageProto::setVisibilityState(QWebPage::VisibilityState state)
 {
   QWebPage *item = qscriptvalue_cast<QWebPage*>(thisObject());
   if (item)
-    return item->setVisibilityState(item->visibilityState());
+    item->setVisibilityState(state);
 }
+#endif
 
 QWebSettings* QWebPageProto::settings() const
 {
@@ -389,7 +390,7 @@ void QWebPageProto::triggerAction(QWebPage::WebAction action, bool checked)
 {
   QWebPage *item = qscriptvalue_cast<QWebPage*>(thisObject());
   if (item)
-    return item->triggerAction(action, checked);
+    item->triggerAction(action, checked);
 }
 
 QUndoStack* QWebPageProto::undoStack() const
@@ -404,7 +405,7 @@ void QWebPageProto::updatePositionDependentActions(const QPoint & pos)
 {
   QWebPage *item = qscriptvalue_cast<QWebPage*>(thisObject());
   if (item)
-    return item->updatePositionDependentActions(pos);
+    item->updatePositionDependentActions(pos);
 }
 
 QWidget* QWebPageProto::view() const
@@ -431,10 +432,12 @@ QSize QWebPageProto::viewportSize() const
   return QSize();
 }
 
+#if QT_VERSION >= 0x050000
 QWebPage::VisibilityState QWebPageProto::visibilityState() const
 {
   QWebPage *item = qscriptvalue_cast<QWebPage*>(thisObject());
   if (item)
     return item->visibilityState();
-  return QWebPage::VisibilityState();
+  return QWebPage::VisibilityStateVisible; // don't know the best default
 }
+#endif

--- a/scriptapi/qwebpageproto.h
+++ b/scriptapi/qwebpageproto.h
@@ -43,7 +43,9 @@ Q_DECLARE_METATYPE(enum QWebPage::Feature)
 Q_DECLARE_METATYPE(enum QWebPage::FindFlag)
 Q_DECLARE_METATYPE(enum QWebPage::LinkDelegationPolicy)
 Q_DECLARE_METATYPE(enum QWebPage::PermissionPolicy)
+#if QT_VERSION >= 0x050000
 Q_DECLARE_METATYPE(enum QWebPage::VisibilityState)
+#endif
 Q_DECLARE_METATYPE(enum QWebPage::WebAction)
 
 void setupQWebPageProto(QScriptEngine *engine);
@@ -89,7 +91,9 @@ class QWebPageProto : public QObject, public QScriptable
     Q_INVOKABLE void                            setPreferredContentsSize(const QSize & size) const;
     Q_INVOKABLE void                            setView(QWidget * view);
     Q_INVOKABLE void                            setViewportSize(const QSize & size) const;
+#if QT_VERSION >= 0x050000
     Q_INVOKABLE void                            setVisibilityState(QWebPage::VisibilityState);
+#endif
     Q_INVOKABLE QWebSettings                   *settings() const;
     Q_INVOKABLE virtual bool                    shouldInterruptJavaScript();
     Q_INVOKABLE QStringList                     supportedContentTypes() const;
@@ -103,7 +107,9 @@ class QWebPageProto : public QObject, public QScriptable
     Q_INVOKABLE QWidget                        *view() const;
     Q_INVOKABLE QWebPage::ViewportAttributes    viewportAttributesForSize(const QSize & availableSize) const;
     Q_INVOKABLE QSize                           viewportSize() const;
+#if QT_VERSION >= 0x050000
     Q_INVOKABLE QWebPage::VisibilityState       visibilityState() const;
+#endif
 };
 
 #endif

--- a/scriptapi/qwebsocketcorsauthenticatorproto.cpp
+++ b/scriptapi/qwebsocketcorsauthenticatorproto.cpp
@@ -1,0 +1,127 @@
+/*
+ * This file is part of the xTuple ERP: PostBooks Edition, a free and
+ * open source Enterprise Resource Planning software suite,
+ * Copyright (c) 1999-2015 by OpenMFG LLC, d/b/a xTuple.
+ * It is licensed to you under the Common Public Attribution License
+ * version 1.0, the full text of which(including xTuple-specific Exhibits)
+ * is available at www.xtuple.com/CPAL.  By using this software, you agree
+ * to be bound by its terms.
+ */
+
+#include "qwebsocketcorsauthenticatorproto.h"
+
+#if QT_VERSION < 0x050000
+void setupQJsonDocumentProto(QScriptEngine *engine)
+{
+  Q_UNUSED(engine);
+}
+#else
+
+QScriptValue QWebSocketCorsAuthenticatorToScriptValue(QScriptEngine *engine, QWebSocketCorsAuthenticator* const &item)
+{
+  QScriptValue obj = engine->newObject();
+  obj.setProperty("origin",  item->origin());
+  obj.setProperty("allowed", item->allowed());
+  return obj;
+}
+
+void QWebSocketCorsAuthenticatorFromScriptValue(const QScriptValue &obj, QWebSocketCorsAuthenticator* &item)
+{
+  item = new QWebSocketCorsAuthenticator(obj.property("origin").toString());
+  item->setAllowed(obj.property("allowed").toBool());
+}
+
+void setupQWebSocketCorsAuthenticatorProto(QScriptEngine *engine)
+{
+ qScriptRegisterMetaType(engine, QWebSocketCorsAuthenticatorToScriptValue, QWebSocketCorsAuthenticatorFromScriptValue);
+
+  QScriptValue proto = engine->newQObject(new QWebSocketCorsAuthenticatorProto(engine));
+  engine->setDefaultPrototype(qMetaTypeId<QWebSocketCorsAuthenticator*>(), proto);
+
+  QScriptValue constructor = engine->newFunction(constructQWebSocketCorsAuthenticator, proto);
+  engine->globalObject().setProperty("QWebSocketCorsAuthenticator",  constructor);
+}
+
+QScriptValue constructQWebSocketCorsAuthenticator(QScriptContext *context, QScriptEngine *engine)
+{
+  QWebSocketCorsAuthenticator *obj = 0;
+  if (context->argumentCount() >= 1)
+  {
+    QScriptValue arg = context->argument(0);
+    if (arg.isString())
+      obj = new QWebSocketCorsAuthenticator(arg.toString());
+    else
+      QWebSocketCorsAuthenticatorFromScriptValue(arg, obj);
+  }
+  else
+    context->throwError(QScriptContext::UnknownError,
+                        "Could not find an appropriate QWebSocketCorsAuthenticator constructor");
+  return engine->toScriptValue(obj);
+}
+
+QWebSocketCorsAuthenticatorProto::QWebSocketCorsAuthenticatorProto(QObject *parent)
+    : QObject(parent)
+{
+}
+
+QWebSocketCorsAuthenticatorProto::~QWebSocketCorsAuthenticatorProto()
+{
+}
+
+bool QWebSocketCorsAuthenticatorProto::allowed() const
+{
+  QWebSocketCorsAuthenticator *item = qscriptvalue_cast<QWebSocketCorsAuthenticator*>(thisObject());
+  if (item)
+    return item->allowed();
+  return false;
+}
+
+QString QWebSocketCorsAuthenticatorProto::origin() const
+{
+  QWebSocketCorsAuthenticator *item = qscriptvalue_cast<QWebSocketCorsAuthenticator*>(thisObject());
+  if (item)
+    return item->origin();
+  return QString();
+}
+
+void QWebSocketCorsAuthenticatorProto::setAllowed(bool allowed)
+{
+  QWebSocketCorsAuthenticator *item = qscriptvalue_cast<QWebSocketCorsAuthenticator*>(thisObject());
+  if (item)
+    item->setAllowed(allowed);
+}
+
+void QWebSocketCorsAuthenticatorProto::swap(QWebSocketCorsAuthenticator &other)
+{
+  QWebSocketCorsAuthenticator *item = qscriptvalue_cast<QWebSocketCorsAuthenticator*>(thisObject());
+  if (item)
+    item->swap(other);
+}
+
+/*
+QWebSocketCorsAuthenticator QWebSocketCorsAuthenticatorProto::&operator=(QWebSocketCorsAuthenticator &&other)
+{
+  QWebSocketCorsAuthenticator *item = qscriptvalue_cast<QWebSocketCorsAuthenticator*>(thisObject());
+  if (item)
+    return item->operator=(other);
+  return QWebSocktCorsAuthenticator();
+}
+
+QWebSocketCorsAuthenticator QWebSocketCorsAuthenticatorProto::&operator=(const QWebSocketCorsAuthenticator &other)
+{
+  QWebSocketCorsAuthenticator *item = qscriptvalue_cast<QWebSocketCorsAuthenticator*>(thisObject());
+  if (item)
+    return item->&operator=(other);
+  return QWebSocktCorsAuthenticator();
+}
+*/
+
+QString QWebSocketCorsAuthenticatorProto::toString() const
+{
+  QWebSocketCorsAuthenticator *item = qscriptvalue_cast<QWebSocketCorsAuthenticator*>(thisObject());
+  if (item)
+    return item->origin();
+  return QString();
+}
+
+#endif

--- a/scriptapi/qwebsocketcorsauthenticatorproto.cpp
+++ b/scriptapi/qwebsocketcorsauthenticatorproto.cpp
@@ -11,7 +11,7 @@
 #include "qwebsocketcorsauthenticatorproto.h"
 
 #if QT_VERSION < 0x050000
-void setupQJsonDocumentProto(QScriptEngine *engine)
+void setupQWebSocketCorsAuthenticatorProto(QScriptEngine *engine)
 {
   Q_UNUSED(engine);
 }

--- a/scriptapi/qwebsocketcorsauthenticatorproto.h
+++ b/scriptapi/qwebsocketcorsauthenticatorproto.h
@@ -1,0 +1,45 @@
+/*
+ * This file is part of the xTuple ERP: PostBooks Edition, a free and
+ * open source Enterprise Resource Planning software suite,
+ * Copyright (c) 1999-2015 by OpenMFG LLC, d/b/a xTuple.
+ * It is licensed to you under the Common Public Attribution License
+ * version 1.0, the full text of which(including xTuple-specific Exhibits)
+ * is available at www.xtuple.com/CPAL.  By using this software, you agree
+ * to be bound by its terms.
+ */
+
+#ifndef __QWEBSOCKETCORSAUTHENTICATORPROTO_H__
+#define __QWEBSOCKETCORSAUTHENTICATORPROTO_H__
+
+#include <QtScript>
+
+void setupQWebSocketCorsAuthenticatorProto(QScriptEngine *engine);
+
+#if QT_VERSION >= 0x050000
+
+#include <QWebSocketCorsAuthenticator>
+
+Q_DECLARE_METATYPE(QWebSocketCorsAuthenticator*)
+
+QScriptValue constructQWebSocketCorsAuthenticator(QScriptContext *context, QScriptEngine *engine);
+class QWebSocketCorsAuthenticatorProto : public QObject, public QScriptable
+{
+  Q_OBJECT
+
+  public:
+    QWebSocketCorsAuthenticatorProto(QObject *parent = 0);
+    Q_INVOKABLE virtual ~QWebSocketCorsAuthenticatorProto();
+
+    Q_INVOKABLE bool                        allowed() const;
+    Q_INVOKABLE QString                     origin() const;
+    Q_INVOKABLE void                        setAllowed(bool allowed);
+    Q_INVOKABLE void                        swap(QWebSocketCorsAuthenticator &other);
+//  Q_INVOKABLE QWebSocketCorsAuthenticator &operator=(QWebSocketCorsAuthenticator &&other);
+//  Q_INVOKABLE QWebSocketCorsAuthenticator &operator=(const QWebSocketCorsAuthenticator &other);
+
+    Q_INVOKABLE QString                     toString() const;
+};
+
+#endif
+
+#endif

--- a/scriptapi/qwebsocketproto.cpp
+++ b/scriptapi/qwebsocketproto.cpp
@@ -1,0 +1,344 @@
+/*
+ * This file is part of the xTuple ERP: PostBooks Edition, a free and
+ * open source Enterprise Resource Planning software suite,
+ * Copyright (c) 1999-2015 by OpenMFG LLC, d/b/a xTuple.
+ * It is licensed to you under the Common Public Attribution License
+ * version 1.0, the full text of which(including xTuple-specific Exhibits)
+ * is available at www.xtuple.com/CPAL.  By using this software, you agree
+ * to be bound by its terms.
+ */
+
+#include "qwebsocketproto.h"
+
+#if QT_VERSION < 0x050000
+void setupQWebSocketProto(QScriptEngine *engine)
+{
+  Q_UNUSED(engine);
+}
+
+#else
+
+#include <QMaskGenerator>
+
+QScriptValue QWebSocketToScriptValue(QScriptEngine *engine, QWebSocket* const &item)
+{
+  return engine->newQObject(item);
+}
+
+void QWebSocketFromScriptValue(const QScriptValue &obj, QWebSocket* &item)
+{
+  item = qobject_cast<QWebSocket*>(obj.toQObject());
+}
+
+void setupQWebSocketProto(QScriptEngine *engine)
+{
+  qScriptRegisterMetaType(engine, QWebSocketToScriptValue, QWebSocketFromScriptValue);
+
+  QScriptValue proto = engine->newQObject(new QWebSocketProto(engine));
+  engine->setDefaultPrototype(qMetaTypeId<QWebSocket*>(), proto);
+
+  QScriptValue constructor = engine->newFunction(constructQWebSocket, proto);
+  engine->globalObject().setProperty("QWebSocket",  constructor);
+}
+
+QScriptValue constructQWebSocket(QScriptContext *context, QScriptEngine *engine)
+{
+  Q_UNUSED(engine);
+  QWebSocket *obj = 0;
+  if (context->argumentCount() == 3)
+    obj = new QWebSocket(context->argument(0).toString(), (QWebSocketProtocol::Version)context->argument(1).toInt32(), context->argument(2).toQObject());
+  else if (context->argumentCount() == 2)
+    obj = new QWebSocket(context->argument(0).toString(), (QWebSocketProtocol::Version)context->argument(1).toInt32());
+  else if (context->argumentCount() == 1)
+    obj = new QWebSocket(context->argument(0).toString());
+  else
+    obj = new QWebSocket();
+  return engine->toScriptValue(obj);
+}
+
+QWebSocketProto::QWebSocketProto(QObject *parent)
+  : QObject(parent)
+{
+}
+
+QWebSocketProto::~QWebSocketProto()
+{
+}
+
+void QWebSocketProto::abort()
+{
+  QWebSocket *item = qscriptvalue_cast<QWebSocket*>(thisObject());
+  if (item)
+    item->abort();
+}
+
+QWebSocketProtocol::CloseCode QWebSocketProto::closeCode() const
+{
+  QWebSocket *item = qscriptvalue_cast<QWebSocket*>(thisObject());
+  if (item)
+    return item->closeCode();
+  return QWebSocketProtocol::CloseCodeProtocolError;
+}
+
+QString QWebSocketProto::closeReason() const
+{
+  QWebSocket *item = qscriptvalue_cast<QWebSocket*>(thisObject());
+  if (item)
+    return item->closeReason();
+  return QString();
+}
+
+QAbstractSocket::SocketError QWebSocketProto::error() const
+{
+  QWebSocket *item = qscriptvalue_cast<QWebSocket*>(thisObject());
+  if (item)
+    return item->error();
+  return QAbstractSocket::UnknownSocketError;
+}
+
+QString QWebSocketProto::errorString() const
+{
+  QWebSocket *item = qscriptvalue_cast<QWebSocket*>(thisObject());
+  if (item)
+    return item->errorString();
+  return QString("QWebSocketProto::errorString() - could not cast");
+}
+
+bool QWebSocketProto::flush()
+{
+  QWebSocket *item = qscriptvalue_cast<QWebSocket*>(thisObject());
+  if (item)
+    return item->flush();
+  return false;
+}
+
+void QWebSocketProto::ignoreSslErrors(const QList<QSslError> & errors)
+{
+  QWebSocket *item = qscriptvalue_cast<QWebSocket*>(thisObject());
+  if (item)
+    item->ignoreSslErrors(errors);
+}
+
+bool QWebSocketProto::isValid() const
+{
+  QWebSocket *item = qscriptvalue_cast<QWebSocket*>(thisObject());
+  if (item)
+    return item->isValid();
+  return false;
+}
+
+QHostAddress QWebSocketProto::localAddress() const
+{
+  QWebSocket *item = qscriptvalue_cast<QWebSocket*>(thisObject());
+  if (item)
+    return item->localAddress();
+  return QHostAddress();
+}
+
+quint16 QWebSocketProto::localPort() const
+{
+  QWebSocket *item = qscriptvalue_cast<QWebSocket*>(thisObject());
+  if (item)
+    return item->localPort();
+  return 0;
+}
+
+const QMaskGenerator *QWebSocketProto::maskGenerator() const
+{
+  QWebSocket *item = qscriptvalue_cast<QWebSocket*>(thisObject());
+  if (item)
+    return item->maskGenerator();
+  return 0;
+}
+
+QString QWebSocketProto::origin() const
+{
+  QWebSocket *item = qscriptvalue_cast<QWebSocket*>(thisObject());
+  if (item)
+    return item->origin();
+  return QString();
+}
+
+QAbstractSocket::PauseModes QWebSocketProto::pauseMode() const
+{
+  QWebSocket *item = qscriptvalue_cast<QWebSocket*>(thisObject());
+  if (item)
+    return item->pauseMode();
+  return QAbstractSocket::PauseNever;
+}
+
+QHostAddress QWebSocketProto::peerAddress() const
+{
+  QWebSocket *item = qscriptvalue_cast<QWebSocket*>(thisObject());
+  if (item)
+    return item->peerAddress();
+  return QHostAddress();
+}
+
+QString QWebSocketProto::peerName() const
+{
+  QWebSocket *item = qscriptvalue_cast<QWebSocket*>(thisObject());
+  if (item)
+    return item->peerName();
+  return QString();
+}
+
+quint16 QWebSocketProto::peerPort() const
+{
+  QWebSocket *item = qscriptvalue_cast<QWebSocket*>(thisObject());
+  if (item)
+    return item->peerPort();
+  return 0;
+}
+
+QNetworkProxy QWebSocketProto::proxy() const
+{
+  QWebSocket *item = qscriptvalue_cast<QWebSocket*>(thisObject());
+  if (item)
+    return item->proxy();
+  return QNetworkProxy();
+}
+
+qint64 QWebSocketProto::readBufferSize() const
+{
+  QWebSocket *item = qscriptvalue_cast<QWebSocket*>(thisObject());
+  if (item)
+    return item->readBufferSize();
+  return 0;
+}
+
+QUrl QWebSocketProto::requestUrl() const
+{
+  QWebSocket *item = qscriptvalue_cast<QWebSocket*>(thisObject());
+  if (item)
+    return item->requestUrl();
+  return QUrl();
+}
+
+QString QWebSocketProto::resourceName() const
+{
+  QWebSocket *item = qscriptvalue_cast<QWebSocket*>(thisObject());
+  if (item)
+    return item->resourceName();
+  return QString();
+}
+
+void QWebSocketProto::resume()
+{
+  QWebSocket *item = qscriptvalue_cast<QWebSocket*>(thisObject());
+  if (item)
+    item->resume();
+}
+
+qint64 QWebSocketProto::sendBinaryMessage(const QByteArray & data)
+{
+  QWebSocket *item = qscriptvalue_cast<QWebSocket*>(thisObject());
+  if (item)
+    return item->sendBinaryMessage(data);
+  return 0;
+}
+
+qint64 QWebSocketProto::sendTextMessage(const QString & message)
+{
+  QWebSocket *item = qscriptvalue_cast<QWebSocket*>(thisObject());
+  if (item)
+    return item->sendTextMessage(message);
+  return 0;
+}
+
+void QWebSocketProto::setMaskGenerator(const QMaskGenerator * maskGenerator)
+{
+  QWebSocket *item = qscriptvalue_cast<QWebSocket*>(thisObject());
+  if (item)
+    item->setMaskGenerator(maskGenerator);
+}
+
+void QWebSocketProto::setPauseMode(QAbstractSocket::PauseModes pauseMode)
+{
+  QWebSocket *item = qscriptvalue_cast<QWebSocket*>(thisObject());
+  if (item)
+    item->setPauseMode(pauseMode);
+}
+
+void QWebSocketProto::setProxy(const QNetworkProxy & networkProxy)
+{
+  QWebSocket *item = qscriptvalue_cast<QWebSocket*>(thisObject());
+  if (item)
+    item->setProxy(networkProxy);
+}
+
+void QWebSocketProto::setReadBufferSize(qint64 size)
+{
+  QWebSocket *item = qscriptvalue_cast<QWebSocket*>(thisObject());
+  if (item)
+    item->setReadBufferSize(size);
+}
+
+void QWebSocketProto::setSslConfiguration(const QSslConfiguration & sslConfiguration)
+{
+  QWebSocket *item = qscriptvalue_cast<QWebSocket*>(thisObject());
+  if (item)
+    item->setSslConfiguration(sslConfiguration);
+}
+
+QSslConfiguration QWebSocketProto::sslConfiguration() const
+{
+  QWebSocket *item = qscriptvalue_cast<QWebSocket*>(thisObject());
+  if (item)
+    return item->sslConfiguration();
+  return QSslConfiguration();
+}
+
+QAbstractSocket::SocketState QWebSocketProto::state() const
+{
+  QWebSocket *item = qscriptvalue_cast<QWebSocket*>(thisObject());
+  if (item)
+    return item->state();
+  return QAbstractSocket::UnconnectedState;
+}
+
+QWebSocketProtocol::Version QWebSocketProto::version() const
+{
+  QWebSocket *item = qscriptvalue_cast<QWebSocket*>(thisObject());
+  if (item)
+    return item->version();
+  return QWebSocketProtocol::VersionUnknown;
+}
+
+QString QWebSocketProto::toString() const
+{
+  QWebSocket *item = qscriptvalue_cast<QWebSocket*>(thisObject());
+  if (item)
+    return "QWebSocket(" + item->localAddress().toString() + "<->" + item->peerAddress().toString() + ")";
+  return QString("QWebSocket(unknown)");
+}
+
+void QWebSocketProto::close(QWebSocketProtocol::CloseCode closeCode, const QString &reason)
+{
+  QWebSocket *item = qscriptvalue_cast<QWebSocket*>(thisObject());
+  if (item)
+    item->close(closeCode, reason);
+}
+
+void QWebSocketProto::ignoreSslErrors()
+{
+  QWebSocket *item = qscriptvalue_cast<QWebSocket*>(thisObject());
+  if (item)
+    item->ignoreSslErrors();
+}
+
+void QWebSocketProto::open(const QUrl &url)
+{
+  QWebSocket *item = qscriptvalue_cast<QWebSocket*>(thisObject());
+  if (item)
+    item->open(url);
+}
+
+void QWebSocketProto::ping(const QByteArray &payload)
+{
+  QWebSocket *item = qscriptvalue_cast<QWebSocket*>(thisObject());
+  if (item)
+    item->ping(payload);
+}
+
+#endif

--- a/scriptapi/qwebsocketproto.h
+++ b/scriptapi/qwebsocketproto.h
@@ -1,0 +1,79 @@
+/*
+ * This file is part of the xTuple ERP: PostBooks Edition, a free and
+ * open source Enterprise Resource Planning software suite,
+ * Copyright (c) 1999-2015 by OpenMFG LLC, d/b/a xTuple.
+ * It is licensed to you under the Common Public Attribution License
+ * version 1.0, the full text of which(including xTuple-specific Exhibits)
+ * is available at www.xtuple.com/CPAL.  By using this software, you agree
+ * to be bound by its terms.
+ */
+
+#ifndef __QWEBSOCKETPROTO_H__
+#define __QWEBSOCKETPROTO_H__
+
+#include <QtScript>
+
+void setupQWebSocketProto(QScriptEngine *engine);
+
+#if QT_VERSION >= 0x050000
+
+#include <QWebSocket>
+class QMaskGenerator;
+
+Q_DECLARE_METATYPE(QWebSocket*)
+
+QScriptValue constructQWebSocket(QScriptContext *context, QScriptEngine *engine);
+class QWebSocketProto :public QObject, public QScriptable
+{
+  Q_OBJECT
+
+  public:
+    QWebSocketProto(QObject *parent = 0);
+    Q_INVOKABLE virtual ~QWebSocketProto();
+
+    Q_INVOKABLE void                          abort();
+    Q_INVOKABLE QWebSocketProtocol::CloseCode closeCode() const;
+    Q_INVOKABLE QString                       closeReason() const;
+    Q_INVOKABLE QAbstractSocket::SocketError  error() const;
+    Q_INVOKABLE QString                       errorString() const;
+    Q_INVOKABLE bool                          flush();
+    Q_INVOKABLE void                          ignoreSslErrors(const QList<QSslError> & errors);
+    Q_INVOKABLE bool                          isValid() const;
+    Q_INVOKABLE QHostAddress                  localAddress() const;
+    Q_INVOKABLE quint16                       localPort() const;
+    Q_INVOKABLE const QMaskGenerator         *maskGenerator() const;
+    Q_INVOKABLE QString                       origin() const;
+    Q_INVOKABLE QAbstractSocket::PauseModes   pauseMode() const;
+    Q_INVOKABLE QHostAddress                  peerAddress() const;
+    Q_INVOKABLE QString                       peerName() const;
+    Q_INVOKABLE quint16                       peerPort() const;
+    Q_INVOKABLE QNetworkProxy                 proxy() const;
+    Q_INVOKABLE qint64                        readBufferSize() const;
+    Q_INVOKABLE QUrl                          requestUrl() const;
+    Q_INVOKABLE QString                       resourceName() const;
+    Q_INVOKABLE void                          resume();
+    Q_INVOKABLE qint64                        sendBinaryMessage(const QByteArray & data);
+    Q_INVOKABLE qint64                        sendTextMessage(const QString & message);
+    Q_INVOKABLE void                          setMaskGenerator(const QMaskGenerator * maskGenerator);
+    Q_INVOKABLE void                          setPauseMode(QAbstractSocket::PauseModes pauseMode);
+    Q_INVOKABLE void                          setProxy(const QNetworkProxy & networkProxy);
+    Q_INVOKABLE void                          setReadBufferSize(qint64 size);
+    Q_INVOKABLE void                          setSslConfiguration(const QSslConfiguration & sslConfiguration);
+    Q_INVOKABLE QSslConfiguration             sslConfiguration() const;
+    Q_INVOKABLE QAbstractSocket::SocketState  state() const;
+    Q_INVOKABLE QWebSocketProtocol::Version   version() const;
+
+    Q_INVOKABLE QString                       toString() const;
+
+  public slots:
+
+    void close(QWebSocketProtocol::CloseCode closeCode = QWebSocketProtocol::CloseCodeNormal, const QString & reason = QString());
+    void ignoreSslErrors();
+    void open(const QUrl & url);
+    void ping(const QByteArray & payload = QByteArray());
+
+};
+
+#endif
+
+#endif

--- a/scriptapi/qwebsocketprotocolproto.cpp
+++ b/scriptapi/qwebsocketprotocolproto.cpp
@@ -1,0 +1,49 @@
+/*
+ * This file is part of the xTuple ERP: PostBooks Edition, a free and
+ * open source Enterprise Resource Planning software suite,
+ * Copyright (c) 1999-2015 by OpenMFG LLC, d/b/a xTuple.
+ * It is licensed to you under the Common Public Attribution License
+ * version 1.0, the full text of which (including xTuple-specific Exhibits)
+ * is available at www.xtuple.com/CPAL.  By using this software, you agree
+ * to be bound by its terms.
+ */
+
+#include "qwebsocketprotocolproto.h"
+
+#if QT_VERSION >= 0x050000
+#include <QWebSocketProtocol>
+#endif
+
+void setupQWebSocketProtocolProto(QScriptEngine *engine)
+{
+  QScriptValue obj = engine->newObject();
+  QScriptValue::PropertyFlags permanent = QScriptValue::ReadOnly | QScriptValue::Undeletable;
+
+#if QT_VERSION >= 0x050000
+  obj.setProperty("CloseCodeNormal",                 QScriptValue(engine, QWebSocketProtocol::CloseCodeNormal),                permanent);
+  obj.setProperty("CloseCodeGoingAway",              QScriptValue(engine, QWebSocketProtocol::CloseCodeGoingAway),             permanent);
+  obj.setProperty("CloseCodeProtocolError",          QScriptValue(engine, QWebSocketProtocol::CloseCodeProtocolError),         permanent);
+  obj.setProperty("CloseCodeDatatypeNotSupported",   QScriptValue(engine, QWebSocketProtocol::CloseCodeDatatypeNotSupported),  permanent);
+  obj.setProperty("CloseCodeReserved1004",           QScriptValue(engine, QWebSocketProtocol::CloseCodeReserved1004),          permanent);
+  obj.setProperty("CloseCodeMissingStatusCode",      QScriptValue(engine, QWebSocketProtocol::CloseCodeMissingStatusCode),     permanent);
+  obj.setProperty("CloseCodeAbnormalDisconnection",  QScriptValue(engine, QWebSocketProtocol::CloseCodeAbnormalDisconnection), permanent);
+  obj.setProperty("CloseCodeWrongDatatype",          QScriptValue(engine, QWebSocketProtocol::CloseCodeWrongDatatype),         permanent);
+  obj.setProperty("CloseCodePolicyViolated",         QScriptValue(engine, QWebSocketProtocol::CloseCodePolicyViolated),        permanent);
+  obj.setProperty("CloseCodeTooMuchData",            QScriptValue(engine, QWebSocketProtocol::CloseCodeTooMuchData),           permanent);
+  obj.setProperty("CloseCodeMissingExtension",       QScriptValue(engine, QWebSocketProtocol::CloseCodeMissingExtension),      permanent);
+  obj.setProperty("CloseCodeBadOperation",           QScriptValue(engine, QWebSocketProtocol::CloseCodeBadOperation),          permanent);
+  obj.setProperty("CloseCodeTlsHandshakeFailed",     QScriptValue(engine, QWebSocketProtocol::CloseCodeTlsHandshakeFailed),    permanent);
+
+  obj.setProperty("VersionUnknown",  QScriptValue(engine, QWebSocketProtocol::VersionUnknown), permanent);
+  obj.setProperty("Version0",        QScriptValue(engine, QWebSocketProtocol::Version0),       permanent);
+  obj.setProperty("Version4",        QScriptValue(engine, QWebSocketProtocol::Version4),       permanent);
+  obj.setProperty("Version5",        QScriptValue(engine, QWebSocketProtocol::Version5),       permanent);
+  obj.setProperty("Version6",        QScriptValue(engine, QWebSocketProtocol::Version6),       permanent);
+  obj.setProperty("Version7",        QScriptValue(engine, QWebSocketProtocol::Version7),       permanent);
+  obj.setProperty("Version8",        QScriptValue(engine, QWebSocketProtocol::Version8),       permanent);
+  obj.setProperty("Version13",       QScriptValue(engine, QWebSocketProtocol::Version13),      permanent);
+  obj.setProperty("VersionLatest",   QScriptValue(engine, QWebSocketProtocol::VersionLatest),  permanent);
+#endif
+
+  engine->globalObject().setProperty("QWebSocketProtocol", obj, permanent);
+}

--- a/scriptapi/qwebsocketprotocolproto.cpp
+++ b/scriptapi/qwebsocketprotocolproto.cpp
@@ -10,10 +10,6 @@
 
 #include "qwebsocketprotocolproto.h"
 
-#if QT_VERSION >= 0x050000
-#include <QWebSocketProtocol>
-#endif
-
 void setupQWebSocketProtocolProto(QScriptEngine *engine)
 {
   QScriptValue obj = engine->newObject();

--- a/scriptapi/qwebsocketprotocolproto.h
+++ b/scriptapi/qwebsocketprotocolproto.h
@@ -1,0 +1,23 @@
+/*
+ * This file is part of the xTuple ERP: PostBooks Edition, a free and
+ * open source Enterprise Resource Planning software suite,
+ * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * It is licensed to you under the Common Public Attribution License
+ * version 1.0, the full text of which (including xTuple-specific Exhibits)
+ * is available at www.xtuple.com/CPAL.  By using this software, you agree
+ * to be bound by its terms.
+ */
+
+#ifndef __QWEBSOCKETPROTOCOLPROTO_H__
+#define __QWEBSOCKETPROTOCOLPROTO_H__
+
+#include <QtScript>
+
+void setupQWebSocketProtocolProto(QScriptEngine *engine);
+
+#if QT_VERSION >= 0x050000
+Q_DECLARE_METATYPE(enum QWebSocketProtocol::CloseCode)
+Q_DECLARE_METATYPE(enum QWebSocketProtocol::Version)
+#endif
+#endif
+

--- a/scriptapi/qwebsocketprotocolproto.h
+++ b/scriptapi/qwebsocketprotocolproto.h
@@ -16,6 +16,8 @@
 void setupQWebSocketProtocolProto(QScriptEngine *engine);
 
 #if QT_VERSION >= 0x050000
+#include <QtWebSockets> // don't know why <QWebSocketProtocol> doesn't exist, at least on Mac
+
 Q_DECLARE_METATYPE(enum QWebSocketProtocol::CloseCode)
 Q_DECLARE_METATYPE(enum QWebSocketProtocol::Version)
 #endif

--- a/scriptapi/qwebsocketserverproto.cpp
+++ b/scriptapi/qwebsocketserverproto.cpp
@@ -1,0 +1,266 @@
+/*
+ * This file is part of the xTuple ERP: PostBooks Edition, a free and
+ * open source Enterprise Resource Planning software suite,
+ * Copyright (c) 1999-2015 by OpenMFG LLC, d/b/a xTuple.
+ * It is licensed to you under the Common Public Attribution License
+ * version 1.0, the full text of which (including xTuple-specific Exhibits)
+ * is available at www.xtuple.com/CPAL.  By using this software, you agree
+ * to be bound by its terms.
+ */
+
+#include "qwebsocketserverproto.h"
+
+#if QT_VERSION < 0x050000
+void setupQWebSocketServerProto(QScriptEngine *engine)
+{
+  Q_UNUSED(engine);
+}
+#else
+QScriptValue QWebSocketServertoScriptValue(QScriptEngine *engine, QWebSocketServer* const &item)
+{
+  return engine->newQObject(item);
+}
+
+void QWebSocketServerfromScriptValue(const QScriptValue &obj, QWebSocketServer* &item)
+{
+  item = qobject_cast<QWebSocketServer*>(obj.toQObject());
+}
+
+void setupQWebSocketServerProto(QScriptEngine *engine)
+{
+  qScriptRegisterMetaType(engine, QWebSocketServertoScriptValue, QWebSocketServerfromScriptValue);
+  QScriptValue::PropertyFlags permanent = QScriptValue::ReadOnly | QScriptValue::Undeletable;
+
+  QScriptValue proto = engine->newQObject(new QWebSocketServerProto(engine));
+  engine->setDefaultPrototype(qMetaTypeId<QWebSocketServer*>(), proto);
+
+  QScriptValue constructor = engine->newFunction(constructQWebSocketServer, proto);
+  engine->globalObject().setProperty("QWebSocketServer",  constructor);
+  proto.setProperty("SecureMode",    QScriptValue(engine, QWebSocketServer::SecureMode),    permanent);
+  proto.setProperty("NonSecureMode", QScriptValue(engine, QWebSocketServer::NonSecureMode), permanent);
+}
+
+QScriptValue constructQWebSocketServer(QScriptContext *context, QScriptEngine *engine)
+{
+  QWebSocketServer *obj = 0;
+  if (context->argumentCount() == 3)
+  {
+    obj = new QWebSocketServer(context->argument(0).toString(),
+                               (QWebSocketServer::SslMode)context->argument(1).toInt32(),
+                               context->argument(2).toQObject());
+  }
+  else if (context->argumentCount() == 2)
+  {
+    obj = new QWebSocketServer(context->argument(0).toString(),
+                               (QWebSocketServer::SslMode)context->argument(1).toInt32());
+  }
+  else
+    context->throwError(QScriptContext::UnknownError,
+                        "Could not find an appropriate QWebSocketServer constructor");
+
+  return engine->toScriptValue(obj);
+}
+
+QWebSocketServerProto::QWebSocketServerProto(QObject *parent)
+    : QObject(parent)
+{
+}
+
+QWebSocketServerProto::~QWebSocketServerProto()
+{
+}
+
+void QWebSocketServerProto::close()
+{
+  QWebSocketServer *item = qscriptvalue_cast<QWebSocketServer*>(thisObject());
+  if (item)
+    item->close();
+}
+
+QWebSocketProtocol::CloseCode QWebSocketServerProto::error() const
+{
+  QWebSocketServer *item = qscriptvalue_cast<QWebSocketServer*>(thisObject());
+  if (item)
+    return item->error();
+  return QWebSocketProtocol::CloseCodeProtocolError;
+}
+
+QString QWebSocketServerProto::errorString() const
+{
+  QWebSocketServer *item = qscriptvalue_cast<QWebSocketServer*>(thisObject());
+  if (item)
+    return item->errorString();
+  return QString();
+}
+
+bool QWebSocketServerProto::hasPendingConnections() const
+{
+  QWebSocketServer *item = qscriptvalue_cast<QWebSocketServer*>(thisObject());
+  if (item)
+    return item->hasPendingConnections();
+  return false;
+}
+
+bool QWebSocketServerProto::isListening() const
+{
+  QWebSocketServer *item = qscriptvalue_cast<QWebSocketServer*>(thisObject());
+  if (item)
+    return item->isListening();
+  return false;
+}
+
+bool QWebSocketServerProto::listen(const QHostAddress & address, quint16 port)
+{
+  QWebSocketServer *item = qscriptvalue_cast<QWebSocketServer*>(thisObject());
+  if (item)
+    return item->listen(address, port);
+  return false;
+}
+
+int QWebSocketServerProto::maxPendingConnections() const
+{
+  QWebSocketServer *item = qscriptvalue_cast<QWebSocketServer*>(thisObject());
+  if (item)
+    return item->maxPendingConnections();
+  return 0;
+}
+
+QWebSocket *QWebSocketServerProto::nextPendingConnection()
+{
+  QWebSocketServer *item = qscriptvalue_cast<QWebSocketServer*>(thisObject());
+  if (item)
+    return item->nextPendingConnection();
+  return 0;
+}
+
+void QWebSocketServerProto::pauseAccepting()
+{
+  QWebSocketServer *item = qscriptvalue_cast<QWebSocketServer*>(thisObject());
+  if (item)
+    item->pauseAccepting();
+}
+
+QNetworkProxy QWebSocketServerProto::proxy() const
+{
+  QWebSocketServer *item = qscriptvalue_cast<QWebSocketServer*>(thisObject());
+  if (item)
+    return item->proxy();
+  return QNetworkProxy();
+}
+
+void QWebSocketServerProto::resumeAccepting()
+{
+  QWebSocketServer *item = qscriptvalue_cast<QWebSocketServer*>(thisObject());
+  if (item)
+    item->resumeAccepting();
+}
+
+QWebSocketServer::SslMode QWebSocketServerProto::secureMode() const
+{
+  QWebSocketServer *item = qscriptvalue_cast<QWebSocketServer*>(thisObject());
+  if (item)
+    return item->secureMode();
+  return QWebSocketServer::NonSecureMode;
+}
+
+QHostAddress QWebSocketServerProto::serverAddress() const
+{
+  QWebSocketServer *item = qscriptvalue_cast<QWebSocketServer*>(thisObject());
+  if (item)
+    return item->serverAddress();
+  return QHostAddress();
+}
+
+QString QWebSocketServerProto::serverName() const
+{
+  QWebSocketServer *item = qscriptvalue_cast<QWebSocketServer*>(thisObject());
+  if (item)
+    return item->serverName();
+  return QString();
+}
+
+quint16 QWebSocketServerProto::serverPort() const
+{
+  QWebSocketServer *item = qscriptvalue_cast<QWebSocketServer*>(thisObject());
+  if (item)
+    return item->serverPort();
+  return 0;
+}
+
+QUrl QWebSocketServerProto::serverUrl() const
+{
+  QWebSocketServer *item = qscriptvalue_cast<QWebSocketServer*>(thisObject());
+  if (item)
+    return item->serverUrl();
+  return QUrl();
+}
+
+void QWebSocketServerProto::setMaxPendingConnections(int numConnections)
+{
+  QWebSocketServer *item = qscriptvalue_cast<QWebSocketServer*>(thisObject());
+  if (item)
+    item->setMaxPendingConnections(numConnections);
+}
+
+void QWebSocketServerProto::setProxy(const QNetworkProxy &networkProxy)
+{
+  QWebSocketServer *item = qscriptvalue_cast<QWebSocketServer*>(thisObject());
+  if (item)
+    item->setProxy(networkProxy);
+}
+
+void QWebSocketServerProto::setServerName(const QString &serverName)
+{
+  QWebSocketServer *item = qscriptvalue_cast<QWebSocketServer*>(thisObject());
+  if (item)
+    item->setServerName(serverName);
+}
+
+bool QWebSocketServerProto::setSocketDescriptor(int socketDescriptor)
+{
+  QWebSocketServer *item = qscriptvalue_cast<QWebSocketServer*>(thisObject());
+  if (item)
+    return item->setSocketDescriptor(socketDescriptor);
+  return false;
+}
+
+void QWebSocketServerProto::setSslConfiguration(const QSslConfiguration & sslConfiguration)
+{
+  QWebSocketServer *item = qscriptvalue_cast<QWebSocketServer*>(thisObject());
+  if (item)
+    item->setSslConfiguration(sslConfiguration);
+}
+
+int QWebSocketServerProto::socketDescriptor() const
+{
+  QWebSocketServer *item = qscriptvalue_cast<QWebSocketServer*>(thisObject());
+  if (item)
+    return item->socketDescriptor();
+  return 0;
+}
+
+QSslConfiguration QWebSocketServerProto::sslConfiguration() const
+{
+  QWebSocketServer *item = qscriptvalue_cast<QWebSocketServer*>(thisObject());
+  if (item)
+    return item->sslConfiguration();
+  return QSslConfiguration();
+}
+
+QList<QWebSocketProtocol::Version> QWebSocketServerProto::supportedVersions() const
+{
+  QWebSocketServer *item = qscriptvalue_cast<QWebSocketServer*>(thisObject());
+  if (item)
+    return item->supportedVersions();
+  return QList<QWebSocketProtocol::Version>();
+}
+
+QString QWebSocketServerProto::toString() const
+{
+  QWebSocketServer *item = qscriptvalue_cast<QWebSocketServer*>(thisObject());
+  if (item)
+    return "QWebSocketServer(" + item->serverAddress().toString() + "," + item->secureMode() + ")";
+  return QString();
+}
+
+#endif

--- a/scriptapi/qwebsocketserverproto.h
+++ b/scriptapi/qwebsocketserverproto.h
@@ -1,0 +1,68 @@
+/*
+ * This file is part of the xTuple ERP: PostBooks Edition, a free and
+ * open source Enterprise Resource Planning software suite,
+ * Copyright (c) 1999-2015 by OpenMFG LLC, d/b/a xTuple.
+ * It is licensed to you under the Common Public Attribution License
+ * version 1.0, the full text of which (including xTuple-specific Exhibits)
+ * is available at www.xtuple.com/CPAL.  By using this software, you agree
+ * to be bound by its terms.
+ */
+
+#ifndef __QWEBSOCKETSERVERPROTO_H__
+#define __QWEBSOCKETSERVERPROTO_H__
+
+#include <QScriptEngine>
+
+void setupQWebSocketServerProto(QScriptEngine *engine);
+
+#if QT_VERSION >= 0x050000
+#include <QNetworkProxy>
+#include <QScriptable>
+#include <QUrl>
+#include <QWebSocketServer>
+
+class QWebSocket;
+
+Q_DECLARE_METATYPE(QWebSocketServer*)
+
+QScriptValue constructQWebSocketServer(QScriptContext *context, QScriptEngine *engine);
+
+class QWebSocketServerProto : public QObject, public QScriptable
+{
+  Q_OBJECT
+
+  public:
+    QWebSocketServerProto(QObject *parent);
+    virtual ~QWebSocketServerProto();
+
+    Q_INVOKABLE void                                close();
+    Q_INVOKABLE QWebSocketProtocol::CloseCode       error() const;
+    Q_INVOKABLE QString                             errorString() const;
+    Q_INVOKABLE bool                                hasPendingConnections() const;
+    Q_INVOKABLE bool                                isListening() const;
+    Q_INVOKABLE bool                                listen(const QHostAddress & address = QHostAddress::Any, quint16 port = 0);
+    Q_INVOKABLE int                                 maxPendingConnections() const;
+    Q_INVOKABLE QWebSocket                         *nextPendingConnection();
+    Q_INVOKABLE void                                pauseAccepting();
+    Q_INVOKABLE QNetworkProxy                       proxy() const;
+    Q_INVOKABLE void                                resumeAccepting();
+    Q_INVOKABLE QWebSocketServer::SslMode           secureMode() const;
+    Q_INVOKABLE QHostAddress                        serverAddress() const;
+    Q_INVOKABLE QString                             serverName() const;
+    Q_INVOKABLE quint16                             serverPort() const;
+    Q_INVOKABLE QUrl                                serverUrl() const;
+    Q_INVOKABLE void                                setMaxPendingConnections(int numConnections);
+    Q_INVOKABLE void                                setProxy(const QNetworkProxy & networkProxy);
+    Q_INVOKABLE void                                setServerName(const QString & serverName);
+    Q_INVOKABLE bool                                setSocketDescriptor(int socketDescriptor);
+    Q_INVOKABLE void                                setSslConfiguration(const QSslConfiguration & sslConfiguration);
+    Q_INVOKABLE int                                 socketDescriptor() const;
+    Q_INVOKABLE QSslConfiguration                   sslConfiguration() const;
+    Q_INVOKABLE QList<QWebSocketProtocol::Version>  supportedVersions() const;
+
+    Q_INVOKABLE QString toString() const;
+
+};
+
+#endif
+#endif

--- a/scriptapi/scriptapi.pro
+++ b/scriptapi/scriptapi.pro
@@ -102,7 +102,8 @@ HEADERS += setupscriptapi.h \
     qvalidatorproto.h \
     qwebframeproto.h \
     qwebpageproto.h \
-    qwebsocketprotocolproto.h \
+    qwebsocketproto.h             \
+    qwebsocketprotocolproto.h     \
     qwebviewproto.h \
     qwidgetproto.h \
     xdatawidgetmapperproto.h \
@@ -212,7 +213,8 @@ SOURCES += setupscriptapi.cpp \
     qvalidatorproto.cpp \
     qwebframeproto.cpp \
     qwebpageproto.cpp \
-    qwebsocketprotocolproto.cpp \
+    qwebsocketproto.cpp           \
+    qwebsocketprotocolproto.cpp   \
     qwebviewproto.cpp \
     qwidgetproto.cpp \
     xdatawidgetmapperproto.cpp \

--- a/scriptapi/scriptapi.pro
+++ b/scriptapi/scriptapi.pro
@@ -105,6 +105,7 @@ HEADERS += setupscriptapi.h \
     qwebsocketcorsauthenticatorproto.h \
     qwebsocketproto.h             \
     qwebsocketprotocolproto.h     \
+    qwebsocketserverproto.h       \
     qwebviewproto.h \
     qwidgetproto.h \
     xdatawidgetmapperproto.h \
@@ -217,6 +218,7 @@ SOURCES += setupscriptapi.cpp \
     qwebsocketcorsauthenticatorproto.cpp \
     qwebsocketproto.cpp           \
     qwebsocketprotocolproto.cpp   \
+    qwebsocketserverproto.cpp     \
     qwebviewproto.cpp \
     qwidgetproto.cpp \
     xdatawidgetmapperproto.cpp \

--- a/scriptapi/scriptapi.pro
+++ b/scriptapi/scriptapi.pro
@@ -102,6 +102,7 @@ HEADERS += setupscriptapi.h \
     qvalidatorproto.h \
     qwebframeproto.h \
     qwebpageproto.h \
+    qwebsocketcorsauthenticatorproto.h \
     qwebsocketproto.h             \
     qwebsocketprotocolproto.h     \
     qwebviewproto.h \
@@ -213,6 +214,7 @@ SOURCES += setupscriptapi.cpp \
     qvalidatorproto.cpp \
     qwebframeproto.cpp \
     qwebpageproto.cpp \
+    qwebsocketcorsauthenticatorproto.cpp \
     qwebsocketproto.cpp           \
     qwebsocketprotocolproto.cpp   \
     qwebviewproto.cpp \

--- a/scriptapi/scriptapi.pro
+++ b/scriptapi/scriptapi.pro
@@ -95,6 +95,7 @@ HEADERS += setupscriptapi.h \
     qvalidatorproto.h \
     qwebframeproto.h \
     qwebpageproto.h \
+    qwebsocketprotocolproto.h \
     qwebviewproto.h \
     qwidgetproto.h \
     xdatawidgetmapperproto.h \
@@ -204,6 +205,7 @@ SOURCES += setupscriptapi.cpp \
     qvalidatorproto.cpp \
     qwebframeproto.cpp \
     qwebpageproto.cpp \
+    qwebsocketprotocolproto.cpp \
     qwebviewproto.cpp \
     qwidgetproto.cpp \
     xdatawidgetmapperproto.cpp \

--- a/scriptapi/scriptapi.pro
+++ b/scriptapi/scriptapi.pro
@@ -4,6 +4,13 @@ TEMPLATE = lib
 CONFIG += qt \
     warn_on \
     staticlib
+
+QT += core network printsupport script sql webkit webkitwidgets widgets xml
+
+greaterThan (QT_MAJOR_VERSION, 4) {
+  QT += websockets
+}
+
 DBFILE = scriptapi.db
 LANGUAGE = C++
 INCLUDEPATH += $${XTUPLE_DIR}/common          $${XTUPLE_BLD}/common \
@@ -238,13 +245,3 @@ SOURCES += setupscriptapi.cpp \
     xvariantsetup.cpp \
     xwebsync.cpp \
     xwebsyncproto.cpp
-
-QT += core \
-    sql \
-    xml \
-    script \
-    network \
-    webkit \
-    webkitwidgets \
-    widgets \
-    printsupport

--- a/scriptapi/setupscriptapi.cpp
+++ b/scriptapi/setupscriptapi.cpp
@@ -105,6 +105,7 @@
 #include "qwebsocketcorsauthenticatorproto.h"
 #include "qwebsocketproto.h"
 #include "qwebsocketprotocolproto.h"
+#include "qwebsocketserverproto.h"
 #include "qwebviewproto.h"
 #include "qwidgetproto.h"
 #include "ralineeditsetup.h"
@@ -238,6 +239,7 @@ void setupScriptApi(QScriptEngine *engine)
   setupQWebSocketCorsAuthenticatorProto(engine);
   setupQWebSocketProto(engine);
   setupQWebSocketProtocolProto(engine);
+  setupQWebSocketServerProto(engine);
   setupQWebViewProto(engine);
   setupQWidgetProto(engine);
   setupRaLineEdit(engine);

--- a/scriptapi/setupscriptapi.cpp
+++ b/scriptapi/setupscriptapi.cpp
@@ -102,6 +102,7 @@
 #include "qvalidatorproto.h"
 #include "qwebframeproto.h"
 #include "qwebpageproto.h"
+#include "qwebsocketcorsauthenticatorproto.h"
 #include "qwebsocketproto.h"
 #include "qwebsocketprotocolproto.h"
 #include "qwebviewproto.h"
@@ -234,6 +235,7 @@ void setupScriptApi(QScriptEngine *engine)
   setupQValidatorProto(engine);
   setupQWebFrameProto(engine);
   setupQWebPageProto(engine);
+  setupQWebSocketCorsAuthenticatorProto(engine);
   setupQWebSocketProto(engine);
   setupQWebSocketProtocolProto(engine);
   setupQWebViewProto(engine);

--- a/scriptapi/setupscriptapi.cpp
+++ b/scriptapi/setupscriptapi.cpp
@@ -125,8 +125,6 @@
 #include "xsqlqueryproto.h"
 #include "xtreewidget.h"
 #include "xvariantsetup.h"
-#include "xwebsync_p.h"
-#include "xwebsync.h"
 #include "xwebsyncproto.h"
 
 /*! \defgroup scriptapi The xTuple ERP Scripting API

--- a/scriptapi/setupscriptapi.cpp
+++ b/scriptapi/setupscriptapi.cpp
@@ -102,6 +102,7 @@
 #include "qvalidatorproto.h"
 #include "qwebframeproto.h"
 #include "qwebpageproto.h"
+#include "qwebsocketproto.h"
 #include "qwebsocketprotocolproto.h"
 #include "qwebviewproto.h"
 #include "qwidgetproto.h"
@@ -233,6 +234,7 @@ void setupScriptApi(QScriptEngine *engine)
   setupQValidatorProto(engine);
   setupQWebFrameProto(engine);
   setupQWebPageProto(engine);
+  setupQWebSocketProto(engine);
   setupQWebSocketProtocolProto(engine);
   setupQWebViewProto(engine);
   setupQWidgetProto(engine);

--- a/scriptapi/setupscriptapi.cpp
+++ b/scriptapi/setupscriptapi.cpp
@@ -102,6 +102,7 @@
 #include "qvalidatorproto.h"
 #include "qwebframeproto.h"
 #include "qwebpageproto.h"
+#include "qwebsocketprotocolproto.h"
 #include "qwebviewproto.h"
 #include "qwidgetproto.h"
 #include "ralineeditsetup.h"
@@ -232,6 +233,7 @@ void setupScriptApi(QScriptEngine *engine)
   setupQValidatorProto(engine);
   setupQWebFrameProto(engine);
   setupQWebPageProto(engine);
+  setupQWebSocketProtocolProto(engine);
   setupQWebViewProto(engine);
   setupQWidgetProto(engine);
   setupRaLineEdit(engine);

--- a/scriptapi/xwebsync.cpp
+++ b/scriptapi/xwebsync.cpp
@@ -113,26 +113,6 @@ QString XWebSync::title() const
 */
 
 /*!
-  \property XWebSync::test
-  \brief the test of the XWebSync
- */
-/*
-void XWebSync::setTest(const QJsonObject &test)
-{
-  Q_D(XWebSync);
-  if (d->test != test) {
-      d->test = test;
-      emit testChanged(d->test);
-  }
-}
-
-QJsonObject XWebSync::test() const
-{
-  Q_D(const XWebSync);
-  return d->test;
-}
-*/
-/*!
   \fn void XWebSync::testChanged(QJsonObject &test)
 
   This signal is emitted whenever the test of the web sync changes.
@@ -140,15 +120,6 @@ QJsonObject XWebSync::test() const
 
   \sa XWebSync::test()
 */
-
-/*!
-  \brief the title of the XWebSync
- */
-//void XWebSync::execute()
-//{
-//  Q_D(XWebSync);
-//  emit executeRequest();
-//}
 
 /*!
   \fn void XWebSync::executeRequest()

--- a/scriptapi/xwebsync.h
+++ b/scriptapi/xwebsync.h
@@ -12,7 +12,6 @@
 #define __XWEBSYNC_H__
 
 #include <QObject>
-#include <QJsonObject>
 
 class XWebSyncPrivate;
 
@@ -22,7 +21,6 @@ class XWebSync : public QObject
   Q_PROPERTY(QString data READ data WRITE setData NOTIFY dataChanged)
   Q_PROPERTY(QString query READ query WRITE setQuery NOTIFY queryChanged)
   Q_PROPERTY(QString title READ title WRITE setTitle NOTIFY titleChanged)
-  //Q_PROPERTY(QJsonObject test READ test WRITE setTest NOTIFY testChanged)
 
   public:
     explicit XWebSync(QObject *parent = 0);
@@ -31,21 +29,15 @@ class XWebSync : public QObject
     void setData(const QString &data);
     void setQuery(const QString &query);
     void setTitle(const QString &title);
-    //void setTest(const QJsonObject &test);
     QString data() const;
     QString query() const;
     QString title() const;
-    //QJsonObject test() const;
-
-  //public Q_SLOTS:
-  //  void execute();
 
   Q_SIGNALS:
     void executeRequest();
     void dataChanged(const QString &data);
     void queryChanged(const QString &query);
     void titleChanged(const QString &title);
-    //void testChanged(const QJsonObject &test);
 
   private:
     Q_DISABLE_COPY(XWebSync)

--- a/scriptapi/xwebsync_p.h
+++ b/scriptapi/xwebsync_p.h
@@ -11,7 +11,6 @@
 #ifndef __XWEBSYNC_P_H__
 #define __XWEBSYNC_P_H__
 
-#include <QJsonObject>
 #include <QString>
 
 class XWebSyncPrivate
@@ -21,7 +20,6 @@ class XWebSyncPrivate
     QString data;
     QString query;
     QString title;
-    //QJsonObject test;
 };
 
 #endif

--- a/scriptapi/xwebsyncproto.cpp
+++ b/scriptapi/xwebsyncproto.cpp
@@ -12,17 +12,27 @@
 
 #include <QObject>
 
+#if QT_VERSION >= 0x050000
 QScriptValue XWebSynctoScriptValue(QScriptEngine *engine, QJsonObject const &item)
 {
-  //return engine->newQObject(item);
   return engine->newVariant(QVariant(&item));
 }
 
 void XWebSyncfromScriptValue(const QScriptValue &obj, QJsonObject &item)
 {
-  //item = qobject_cast<QJsonValue*>(obj.toQObject());
   item = QVariant(obj.toVariant()).toJsonObject();
 }
+#else
+QScriptValue XWebSynctoScriptValue(QScriptEngine *engine, QVariant const &item)
+{
+  return engine->newVariant(item);
+}
+
+void XWebSyncfromScriptValue(const QScriptValue &obj, QVariant &item)
+{
+  item = QVariant(obj.toVariant());
+}
+#endif
 
 void setupXWebSyncProto(QScriptEngine *engine)
 {
@@ -77,13 +87,3 @@ QString XWebSyncProto::title() const
     return item->title();
   return QString();
 }
-
-/*
-QJsonObject XWebSyncProto::test() const
-{
-  XWebSync *item = qscriptvalue_cast<XWebSync*>(thisObject());
-  if (item)
-    return item->test();
-  return QJsonObject();
-}
-*/

--- a/scriptapi/xwebsyncproto.h
+++ b/scriptapi/xwebsyncproto.h
@@ -11,7 +11,6 @@
 #ifndef __XWEBSYNCPROTO_H__
 #define __XWEBSYNCPROTO_H__
 
-#include <QJsonObject>
 #include <QtScript>
 
 #include <xwebsync.h>
@@ -31,7 +30,6 @@ class XWebSyncProto : public QObject, public QScriptable
     Q_INVOKABLE QString data() const;
     Q_INVOKABLE QString query() const;
     Q_INVOKABLE QString title() const;
-    //Q_INVOKABLE QJsonObject test() const;
 };
 
 #endif


### PR DESCRIPTION
I don't think qnetworkaccessmanager needs to be exposed at all since the only chunk in `bendiy/expose-qwebframe-to-scripting` is a _signal_. also, there are already xnetworkaccessmanager.* files (don't remember why) that can probably be used if necessary.

The XWebSync classes are strange; if XWebSync is our own class and not derived from an existing class, there should be no need for a prototype - just expose XWebSync itself with Q_PROPERTY and, if necessary, Q_INVOKABLE. The `from` and `to` functions should transform XWebSync objects, not QJsonObjects.